### PR TITLE
Forward s3 access-key as Bearer token to WebDAV

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -465,7 +465,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	if opt.User != "" || opt.Pass != "" {
 		f.srv.SetUserPass(opt.User, opt.Pass)
 	} else if opt.BearerToken != "" {
-		f.setBearerToken(opt.BearerToken)
+		f.SetBearerToken(opt.BearerToken)
 	} else if f.opt.BearerTokenCommand != "" {
 		err = f.fetchAndSetBearerToken()
 		if err != nil {
@@ -507,7 +507,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 }
 
 // sets the BearerToken up
-func (f *Fs) setBearerToken(token string) {
+func (f *Fs) SetBearerToken(token string) {
 	f.opt.BearerToken = token
 	f.srv.SetHeader("Authorization", "Bearer "+token)
 }
@@ -565,7 +565,7 @@ func (f *Fs) fetchAndSetBearerToken() error {
 	if err != nil {
 		return err
 	}
-	f.setBearerToken(token)
+	f.SetBearerToken(token)
 	return nil
 }
 

--- a/cmd/serve/s3/backend.go
+++ b/cmd/serve/s3/backend.go
@@ -40,7 +40,7 @@ func newBackend(opt *Options, w *Server) gofakes3.Backend {
 	}
 }
 
-func (db *s3Backend) setAuthForWebDAV(accessKey string) (*vfs.VFS, error) {
+func (db *s3Backend) setAuthForWebDAV(accessKey string) *vfs.VFS {
 	// new VFS
 	vfs := vfs.NewVfs(db.w.f, &vfsflags.Opt, accessKey)
 
@@ -50,15 +50,12 @@ func (db *s3Backend) setAuthForWebDAV(accessKey string) (*vfs.VFS, error) {
 	if fs, ok := vfsFs.(*webdav.Fs); ok {
 		fs.SetBearerToken(accessKey)
 	}
-	return vfs, nil
+	return vfs
 }
 
 // ListBuckets always returns the default bucket.
 func (db *s3Backend) ListBuckets(accessKey string) ([]gofakes3.BucketInfo, error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return nil, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	dirEntries, err := getDirEntries("/", vf)
 	if err != nil {
@@ -80,12 +77,9 @@ func (db *s3Backend) ListBuckets(accessKey string) ([]gofakes3.BucketInfo, error
 
 // ListBucket lists the objects in the given bucket.
 func (db *s3Backend) ListBucket(accessKey string, bucket string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return nil, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
-	_, err = vf.Stat(bucket)
+	_, err := vf.Stat(bucket)
 	if err != nil {
 		return nil, gofakes3.BucketNotFound(bucket)
 	}
@@ -123,12 +117,9 @@ func (db *s3Backend) ListBucket(accessKey string, bucket string, prefix *gofakes
 //
 // Note that the metadata is not supported yet.
 func (db *s3Backend) HeadObject(accessKey string, bucketName, objectName string) (*gofakes3.Object, error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return nil, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
-	_, err = vf.Stat(bucketName)
+	_, err := vf.Stat(bucketName)
 	if err != nil {
 		return nil, gofakes3.BucketNotFound(bucketName)
 	}
@@ -178,10 +169,7 @@ func (db *s3Backend) HeadObject(accessKey string, bucketName, objectName string)
 
 // GetObject fetchs the object from the filesystem.
 func (db *s3Backend) GetObject(accessKey string, bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (obj *gofakes3.Object, err error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return nil, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	_, err = vf.Stat(bucketName)
 	if err != nil {
@@ -260,10 +248,7 @@ func (db *s3Backend) GetObject(accessKey string, bucketName, objectName string, 
 
 // TouchObject creates or updates meta on specified object.
 func (db *s3Backend) TouchObject(accessKey string, fp string, meta map[string]string) (result gofakes3.PutObjectResult, err error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return result, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	_, err = vf.Stat(fp)
 	if err == vfs.ENOENT {
@@ -310,10 +295,7 @@ func (db *s3Backend) PutObject(
 	meta map[string]string,
 	input io.Reader, size int64,
 ) (result gofakes3.PutObjectResult, err error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return result, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	_, err = vf.Stat(bucketName)
 	if err != nil {
@@ -390,10 +372,7 @@ func (db *s3Backend) PutObject(
 
 // DeleteMulti deletes multiple objects in a single request.
 func (db *s3Backend) DeleteMulti(accessKey string, bucketName string, objects ...string) (result gofakes3.MultiDeleteResult, rerr error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return result, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	db.lock.Lock()
 	defer db.lock.Unlock()
@@ -418,10 +397,7 @@ func (db *s3Backend) DeleteMulti(accessKey string, bucketName string, objects ..
 
 // DeleteObject deletes the object with the given name.
 func (db *s3Backend) DeleteObject(accessKey string, bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return result, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	db.lock.Lock()
 	defer db.lock.Unlock()
@@ -452,12 +428,9 @@ func (db *s3Backend) deleteObjectLocked(vf *vfs.VFS, bucketName, objectName stri
 
 // CreateBucket creates a new bucket.
 func (db *s3Backend) CreateBucket(accessKey string, name string) error {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
-	_, err = vf.Stat(name)
+	_, err := vf.Stat(name)
 	if err != nil && err != vfs.ENOENT {
 		return gofakes3.ErrInternal
 	}
@@ -474,12 +447,9 @@ func (db *s3Backend) CreateBucket(accessKey string, name string) error {
 
 // DeleteBucket deletes the bucket with the given name.
 func (db *s3Backend) DeleteBucket(accessKey string, name string) error {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
-	_, err = vf.Stat(name)
+	_, err := vf.Stat(name)
 	if err != nil {
 		return gofakes3.BucketNotFound(name)
 	}
@@ -493,10 +463,7 @@ func (db *s3Backend) DeleteBucket(accessKey string, name string) error {
 
 // BucketExists checks if the bucket exists.
 func (db *s3Backend) BucketExists(accessKey string, name string) (exists bool, err error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return false, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	_, err = vf.Stat(name)
 	if err != nil {
@@ -508,10 +475,7 @@ func (db *s3Backend) BucketExists(accessKey string, name string) (exists bool, e
 
 // CopyObject copy specified object from srcKey to dstKey.
 func (db *s3Backend) CopyObject(accessKey string, srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
-	vf, err := db.setAuthForWebDAV(accessKey)
-	if err != nil {
-		return result, err
-	}
+	vf := db.setAuthForWebDAV(accessKey)
 
 	fp := path.Join(srcBucket, srcKey)
 	if srcBucket == dstBucket && srcKey == dstKey {

--- a/cmd/serve/s3/backend.go
+++ b/cmd/serve/s3/backend.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/Mikubill/gofakes3"
 	"github.com/ncw/swift/v2"
+	"github.com/rclone/rclone/backend/webdav"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/vfs"
+	"github.com/rclone/rclone/vfs/vfsflags"
 )
 
 var (
@@ -27,20 +29,45 @@ var (
 type s3Backend struct {
 	opt  *Options
 	lock sync.Mutex
-	fs   *vfs.VFS
+	w    *Server
 }
 
 // newBackend creates a new SimpleBucketBackend.
-func newBackend(fs *vfs.VFS, opt *Options) gofakes3.Backend {
+func newBackend(opt *Options, w *Server) gofakes3.Backend {
 	return &s3Backend{
-		fs:  fs,
 		opt: opt,
+		w:   w,
 	}
+}
+
+func (db *s3Backend) setAuthForWebDAV(accessKey string) (*vfs.VFS, error) {
+	// new Fs
+	// TODO: assert that args[0] is remote
+	info, name, remote, config, _ := fs.ConfigFs(db.w.args[0])
+	f, err := info.NewFs(context.Background(), name+accessKey, remote, config)
+	if err != nil {
+		return nil, err
+	}
+	// new VFS
+	vfs := vfs.New(f, &vfsflags.Opt)
+
+	vfs.FlushDirCache()
+
+	vfsFs := vfs.Fs()
+	if fs, ok := vfsFs.(*webdav.Fs); ok {
+		fs.SetBearerToken(accessKey)
+	}
+	return vfs, nil
 }
 
 // ListBuckets always returns the default bucket.
 func (db *s3Backend) ListBuckets() ([]gofakes3.BucketInfo, error) {
-	dirEntries, err := getDirEntries("/", db.fs)
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return nil, err
+	}
+
+	dirEntries, err := getDirEntries("/", vf)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +87,12 @@ func (db *s3Backend) ListBuckets() ([]gofakes3.BucketInfo, error) {
 
 // ListBucket lists the objects in the given bucket.
 func (db *s3Backend) ListBucket(bucket string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return nil, err
+	}
 
-	_, err := db.fs.Stat(bucket)
+	_, err = vf.Stat(bucket)
 	if err != nil {
 		return nil, gofakes3.BucketNotFound(bucket)
 	}
@@ -81,11 +112,11 @@ func (db *s3Backend) ListBucket(bucket string, prefix *gofakes3.Prefix, page gof
 	}
 
 	response := gofakes3.NewObjectList()
-	if db.fs.Fs().Features().BucketBased || prefix.HasDelimiter && prefix.Delimiter != "/" {
-		err = db.getObjectsListArbitrary(bucket, prefix, response)
+	if vf.Fs().Features().BucketBased || prefix.HasDelimiter && prefix.Delimiter != "/" {
+		err = db.getObjectsListArbitrary(vf, bucket, prefix, response)
 	} else {
 		path, remaining := prefixParser(prefix)
-		err = db.entryListR(bucket, path, remaining, prefix.HasDelimiter, response)
+		err = db.entryListR(vf, bucket, path, remaining, prefix.HasDelimiter, response)
 	}
 
 	if err != nil {
@@ -99,8 +130,12 @@ func (db *s3Backend) ListBucket(bucket string, prefix *gofakes3.Prefix, page gof
 //
 // Note that the metadata is not supported yet.
 func (db *s3Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return nil, err
+	}
 
-	_, err := db.fs.Stat(bucketName)
+	_, err = vf.Stat(bucketName)
 	if err != nil {
 		return nil, gofakes3.BucketNotFound(bucketName)
 	}
@@ -109,7 +144,7 @@ func (db *s3Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object
 	defer db.lock.Unlock()
 
 	fp := path.Join(bucketName, objectName)
-	node, err := db.fs.Stat(fp)
+	node, err := vf.Stat(fp)
 	if err != nil {
 		return nil, gofakes3.KeyNotFound(objectName)
 	}
@@ -150,8 +185,12 @@ func (db *s3Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object
 
 // GetObject fetchs the object from the filesystem.
 func (db *s3Backend) GetObject(bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (obj *gofakes3.Object, err error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return nil, err
+	}
 
-	_, err = db.fs.Stat(bucketName)
+	_, err = vf.Stat(bucketName)
 	if err != nil {
 		return nil, gofakes3.BucketNotFound(bucketName)
 	}
@@ -160,7 +199,7 @@ func (db *s3Backend) GetObject(bucketName, objectName string, rangeRequest *gofa
 	defer db.lock.Unlock()
 
 	fp := path.Join(bucketName, objectName)
-	node, err := db.fs.Stat(fp)
+	node, err := vf.Stat(fp)
 	if err != nil {
 		return nil, gofakes3.KeyNotFound(objectName)
 	}
@@ -228,10 +267,14 @@ func (db *s3Backend) GetObject(bucketName, objectName string, rangeRequest *gofa
 
 // TouchObject creates or updates meta on specified object.
 func (db *s3Backend) TouchObject(fp string, meta map[string]string) (result gofakes3.PutObjectResult, err error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return result, err
+	}
 
-	_, err = db.fs.Stat(fp)
+	_, err = vf.Stat(fp)
 	if err == vfs.ENOENT {
-		f, err := db.fs.Create(fp)
+		f, err := vf.Create(fp)
 		if err != nil {
 			return result, err
 		}
@@ -241,7 +284,7 @@ func (db *s3Backend) TouchObject(fp string, meta map[string]string) (result gofa
 		return result, err
 	}
 
-	_, err = db.fs.Stat(fp)
+	_, err = vf.Stat(fp)
 	if err != nil {
 		return result, err
 	}
@@ -251,7 +294,7 @@ func (db *s3Backend) TouchObject(fp string, meta map[string]string) (result gofa
 	if val, ok := meta["X-Amz-Meta-Mtime"]; ok {
 		ti, err := swift.FloatStringToTime(val)
 		if err == nil {
-			return result, db.fs.Chtimes(fp, ti, ti)
+			return result, vf.Chtimes(fp, ti, ti)
 		}
 		// ignore error since the file is successfully created
 	}
@@ -259,7 +302,7 @@ func (db *s3Backend) TouchObject(fp string, meta map[string]string) (result gofa
 	if val, ok := meta["mtime"]; ok {
 		ti, err := swift.FloatStringToTime(val)
 		if err == nil {
-			return result, db.fs.Chtimes(fp, ti, ti)
+			return result, vf.Chtimes(fp, ti, ti)
 		}
 		// ignore error since the file is successfully created
 	}
@@ -273,8 +316,12 @@ func (db *s3Backend) PutObject(
 	meta map[string]string,
 	input io.Reader, size int64,
 ) (result gofakes3.PutObjectResult, err error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return result, err
+	}
 
-	_, err = db.fs.Stat(bucketName)
+	_, err = vf.Stat(bucketName)
 	if err != nil {
 		return result, gofakes3.BucketNotFound(bucketName)
 	}
@@ -284,14 +331,14 @@ func (db *s3Backend) PutObject(
 
 	fp := path.Join(bucketName, objectName)
 	objectDir := path.Dir(fp)
-	// _, err = db.fs.Stat(objectDir)
+	// _, err = vf.Stat(objectDir)
 	// if err == vfs.ENOENT {
 	// 	fs.Errorf(objectDir, "PutObject failed: path not found")
 	// 	return result, gofakes3.KeyNotFound(objectName)
 	// }
 
 	if objectDir != "." {
-		if err := mkdirRecursive(objectDir, db.fs); err != nil {
+		if err := mkdirRecursive(objectDir, vf); err != nil {
 			return result, err
 		}
 	}
@@ -301,7 +348,7 @@ func (db *s3Backend) PutObject(
 		return db.TouchObject(fp, meta)
 	}
 
-	f, err := db.fs.Create(fp)
+	f, err := vf.Create(fp)
 	if err != nil {
 		return result, err
 	}
@@ -311,17 +358,17 @@ func (db *s3Backend) PutObject(
 	if _, err := io.Copy(w, input); err != nil {
 		// remove file when i/o error occurred (FsPutErr)
 		_ = f.Close()
-		_ = db.fs.Remove(fp)
+		_ = vf.Remove(fp)
 		return result, err
 	}
 
 	if err := f.Close(); err != nil {
 		// remove file when close error occurred (FsPutErr)
-		_ = db.fs.Remove(fp)
+		_ = vf.Remove(fp)
 		return result, err
 	}
 
-	_, err = db.fs.Stat(fp)
+	_, err = vf.Stat(fp)
 	if err != nil {
 		return result, err
 	}
@@ -331,7 +378,7 @@ func (db *s3Backend) PutObject(
 	if val, ok := meta["X-Amz-Meta-Mtime"]; ok {
 		ti, err := swift.FloatStringToTime(val)
 		if err == nil {
-			return result, db.fs.Chtimes(fp, ti, ti)
+			return result, vf.Chtimes(fp, ti, ti)
 		}
 		// ignore error since the file is successfully created
 	}
@@ -339,7 +386,7 @@ func (db *s3Backend) PutObject(
 	if val, ok := meta["mtime"]; ok {
 		ti, err := swift.FloatStringToTime(val)
 		if err == nil {
-			return result, db.fs.Chtimes(fp, ti, ti)
+			return result, vf.Chtimes(fp, ti, ti)
 		}
 		// ignore error since the file is successfully created
 	}
@@ -349,11 +396,16 @@ func (db *s3Backend) PutObject(
 
 // DeleteMulti deletes multiple objects in a single request.
 func (db *s3Backend) DeleteMulti(bucketName string, objects ...string) (result gofakes3.MultiDeleteResult, rerr error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return result, err
+	}
+
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
 	for _, object := range objects {
-		if err := db.deleteObjectLocked(bucketName, object); err != nil {
+		if err := db.deleteObjectLocked(vf, bucketName, object); err != nil {
 			log.Println("delete object failed:", err)
 			result.Error = append(result.Error, gofakes3.ErrorResult{
 				Code:    gofakes3.ErrInternal,
@@ -372,16 +424,20 @@ func (db *s3Backend) DeleteMulti(bucketName string, objects ...string) (result g
 
 // DeleteObject deletes the object with the given name.
 func (db *s3Backend) DeleteObject(bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return result, err
+	}
+
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	return result, db.deleteObjectLocked(bucketName, objectName)
+	return result, db.deleteObjectLocked(vf, bucketName, objectName)
 }
 
 // deleteObjectLocked deletes the object from the filesystem.
-func (db *s3Backend) deleteObjectLocked(bucketName, objectName string) error {
-
-	_, err := db.fs.Stat(bucketName)
+func (db *s3Backend) deleteObjectLocked(vf *vfs.VFS, bucketName, objectName string) error {
+	_, err := vf.Stat(bucketName)
 	if err != nil {
 		return gofakes3.BucketNotFound(bucketName)
 	}
@@ -389,20 +445,25 @@ func (db *s3Backend) deleteObjectLocked(bucketName, objectName string) error {
 	fp := path.Join(bucketName, objectName)
 	// S3 does not report an error when attemping to delete a key that does not exist, so
 	// we need to skip IsNotExist errors.
-	if err := db.fs.Remove(fp); err != nil && !os.IsNotExist(err) {
+	if err := vf.Remove(fp); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
 	// fixme: unsafe operation
-	if db.fs.Fs().Features().CanHaveEmptyDirectories {
-		rmdirRecursive(fp, db.fs)
+	if vf.Fs().Features().CanHaveEmptyDirectories {
+		rmdirRecursive(fp, vf)
 	}
 	return nil
 }
 
 // CreateBucket creates a new bucket.
 func (db *s3Backend) CreateBucket(name string) error {
-	_, err := db.fs.Stat(name)
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return err
+	}
+
+	_, err = vf.Stat(name)
 	if err != nil && err != vfs.ENOENT {
 		return gofakes3.ErrInternal
 	}
@@ -411,7 +472,7 @@ func (db *s3Backend) CreateBucket(name string) error {
 		return gofakes3.ErrBucketAlreadyExists
 	}
 
-	if err := db.fs.Mkdir(name, 0755); err != nil {
+	if err := vf.Mkdir(name, 0755); err != nil {
 		return gofakes3.ErrInternal
 	}
 	return nil
@@ -419,12 +480,17 @@ func (db *s3Backend) CreateBucket(name string) error {
 
 // DeleteBucket deletes the bucket with the given name.
 func (db *s3Backend) DeleteBucket(name string) error {
-	_, err := db.fs.Stat(name)
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return err
+	}
+
+	_, err = vf.Stat(name)
 	if err != nil {
 		return gofakes3.BucketNotFound(name)
 	}
 
-	if err := db.fs.Remove(name); err != nil {
+	if err := vf.Remove(name); err != nil {
 		return gofakes3.ErrBucketNotEmpty
 	}
 
@@ -433,7 +499,12 @@ func (db *s3Backend) DeleteBucket(name string) error {
 
 // BucketExists checks if the bucket exists.
 func (db *s3Backend) BucketExists(name string) (exists bool, err error) {
-	_, err = db.fs.Stat(name)
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return false, err
+	}
+
+	_, err = vf.Stat(name)
 	if err != nil {
 		return false, nil
 	}
@@ -443,6 +514,10 @@ func (db *s3Backend) BucketExists(name string) (exists bool, err error) {
 
 // CopyObject copy specified object from srcKey to dstKey.
 func (db *s3Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
+	vf, err := db.setAuthForWebDAV("dummy")
+	if err != nil {
+		return result, err
+	}
 
 	fp := path.Join(srcBucket, srcKey)
 	if srcBucket == dstBucket && srcKey == dstKey {
@@ -460,10 +535,10 @@ func (db *s3Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, met
 			return result, nil
 		}
 
-		return result, db.fs.Chtimes(fp, ti, ti)
+		return result, vf.Chtimes(fp, ti, ti)
 	}
 
-	cStat, err := db.fs.Stat(fp)
+	cStat, err := vf.Stat(fp)
 	if err != nil {
 		return
 	}

--- a/cmd/serve/s3/backend.go
+++ b/cmd/serve/s3/backend.go
@@ -45,11 +45,9 @@ func (db *s3Backend) setAuthForWebDAV(accessKey string) *vfs.VFS {
 	if _, ok := db.w.f.(*webdav.Fs); ok {
 		info, name, remote, config, _ := fs.ConfigFs(db.w.f.Name() + ":")
 		f, _ := info.NewFs(context.Background(), name+accessKey, remote, config)
-		vfs := vfs.New(f, &vfsflags.Opt)
-		vfsFs := vfs.Fs()
-		fs := vfsFs.(*webdav.Fs)
-		fs.SetBearerToken(accessKey)
-		return vfs
+		vf := vfs.New(f, &vfsflags.Opt)
+		vf.Fs().(*webdav.Fs).SetBearerToken(accessKey)
+		return vf
 	}
 	return vfs.New(db.w.f, &vfsflags.Opt)
 }

--- a/cmd/serve/s3/backend.go
+++ b/cmd/serve/s3/backend.go
@@ -41,15 +41,8 @@ func newBackend(opt *Options, w *Server) gofakes3.Backend {
 }
 
 func (db *s3Backend) setAuthForWebDAV(accessKey string) (*vfs.VFS, error) {
-	// new Fs
-	// TODO: assert that args[0] is remote
-	info, name, remote, config, _ := fs.ConfigFs(db.w.args[0])
-	f, err := info.NewFs(context.Background(), name+accessKey, remote, config)
-	if err != nil {
-		return nil, err
-	}
 	// new VFS
-	vfs := vfs.New(f, &vfsflags.Opt)
+	vfs := vfs.NewVfs(db.w.f, &vfsflags.Opt, accessKey)
 
 	vfs.FlushDirCache()
 

--- a/cmd/serve/s3/backend.go
+++ b/cmd/serve/s3/backend.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Mikubill/gofakes3"
+	"github.com/JankariTech/gofakes3"
 	"github.com/ncw/swift/v2"
 	"github.com/rclone/rclone/backend/webdav"
 	"github.com/rclone/rclone/fs"
@@ -61,8 +61,8 @@ func (db *s3Backend) setAuthForWebDAV(accessKey string) (*vfs.VFS, error) {
 }
 
 // ListBuckets always returns the default bucket.
-func (db *s3Backend) ListBuckets() ([]gofakes3.BucketInfo, error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) ListBuckets(accessKey string) ([]gofakes3.BucketInfo, error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +86,8 @@ func (db *s3Backend) ListBuckets() ([]gofakes3.BucketInfo, error) {
 }
 
 // ListBucket lists the objects in the given bucket.
-func (db *s3Backend) ListBucket(bucket string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) ListBucket(accessKey string, bucket string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return nil, err
 	}
@@ -129,8 +129,8 @@ func (db *s3Backend) ListBucket(bucket string, prefix *gofakes3.Prefix, page gof
 // HeadObject returns the fileinfo for the given object name.
 //
 // Note that the metadata is not supported yet.
-func (db *s3Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) HeadObject(accessKey string, bucketName, objectName string) (*gofakes3.Object, error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return nil, err
 	}
@@ -184,8 +184,8 @@ func (db *s3Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object
 }
 
 // GetObject fetchs the object from the filesystem.
-func (db *s3Backend) GetObject(bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (obj *gofakes3.Object, err error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) GetObject(accessKey string, bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (obj *gofakes3.Object, err error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return nil, err
 	}
@@ -266,8 +266,8 @@ func (db *s3Backend) GetObject(bucketName, objectName string, rangeRequest *gofa
 }
 
 // TouchObject creates or updates meta on specified object.
-func (db *s3Backend) TouchObject(fp string, meta map[string]string) (result gofakes3.PutObjectResult, err error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) TouchObject(accessKey string, fp string, meta map[string]string) (result gofakes3.PutObjectResult, err error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return result, err
 	}
@@ -279,7 +279,7 @@ func (db *s3Backend) TouchObject(fp string, meta map[string]string) (result gofa
 			return result, err
 		}
 		_ = f.Close()
-		return db.TouchObject(fp, meta)
+		return db.TouchObject(accessKey, fp, meta)
 	} else if err != nil {
 		return result, err
 	}
@@ -312,11 +312,12 @@ func (db *s3Backend) TouchObject(fp string, meta map[string]string) (result gofa
 
 // PutObject creates or overwrites the object with the given name.
 func (db *s3Backend) PutObject(
+	accessKey string,
 	bucketName, objectName string,
 	meta map[string]string,
 	input io.Reader, size int64,
 ) (result gofakes3.PutObjectResult, err error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return result, err
 	}
@@ -345,7 +346,7 @@ func (db *s3Backend) PutObject(
 
 	if size == 0 {
 		// maybe a touch operation
-		return db.TouchObject(fp, meta)
+		return db.TouchObject(accessKey, fp, meta)
 	}
 
 	f, err := vf.Create(fp)
@@ -395,8 +396,8 @@ func (db *s3Backend) PutObject(
 }
 
 // DeleteMulti deletes multiple objects in a single request.
-func (db *s3Backend) DeleteMulti(bucketName string, objects ...string) (result gofakes3.MultiDeleteResult, rerr error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) DeleteMulti(accessKey string, bucketName string, objects ...string) (result gofakes3.MultiDeleteResult, rerr error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return result, err
 	}
@@ -423,8 +424,8 @@ func (db *s3Backend) DeleteMulti(bucketName string, objects ...string) (result g
 }
 
 // DeleteObject deletes the object with the given name.
-func (db *s3Backend) DeleteObject(bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) DeleteObject(accessKey string, bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return result, err
 	}
@@ -457,8 +458,8 @@ func (db *s3Backend) deleteObjectLocked(vf *vfs.VFS, bucketName, objectName stri
 }
 
 // CreateBucket creates a new bucket.
-func (db *s3Backend) CreateBucket(name string) error {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) CreateBucket(accessKey string, name string) error {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return err
 	}
@@ -479,8 +480,8 @@ func (db *s3Backend) CreateBucket(name string) error {
 }
 
 // DeleteBucket deletes the bucket with the given name.
-func (db *s3Backend) DeleteBucket(name string) error {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) DeleteBucket(accessKey string, name string) error {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return err
 	}
@@ -498,8 +499,8 @@ func (db *s3Backend) DeleteBucket(name string) error {
 }
 
 // BucketExists checks if the bucket exists.
-func (db *s3Backend) BucketExists(name string) (exists bool, err error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) BucketExists(accessKey string, name string) (exists bool, err error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return false, err
 	}
@@ -513,8 +514,8 @@ func (db *s3Backend) BucketExists(name string) (exists bool, err error) {
 }
 
 // CopyObject copy specified object from srcKey to dstKey.
-func (db *s3Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
-	vf, err := db.setAuthForWebDAV("dummy")
+func (db *s3Backend) CopyObject(accessKey string, srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
+	vf, err := db.setAuthForWebDAV(accessKey)
 	if err != nil {
 		return result, err
 	}
@@ -543,7 +544,7 @@ func (db *s3Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, met
 		return
 	}
 
-	c, err := db.GetObject(srcBucket, srcKey, nil)
+	c, err := db.GetObject(accessKey, srcBucket, srcKey, nil)
 	if err != nil {
 		return
 	}
@@ -560,7 +561,7 @@ func (db *s3Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, met
 		meta["mtime"] = swift.TimeToFloatString(cStat.ModTime())
 	}
 
-	_, err = db.PutObject(dstBucket, dstKey, meta, c.Contents, c.Size)
+	_, err = db.PutObject(accessKey, dstBucket, dstKey, meta, c.Contents, c.Size)
 	if err != nil {
 		return
 	}

--- a/cmd/serve/s3/list.go
+++ b/cmd/serve/s3/list.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/Mikubill/gofakes3"
+	"github.com/JankariTech/gofakes3"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/walk"
 	"github.com/rclone/rclone/vfs"

--- a/cmd/serve/s3/list.go
+++ b/cmd/serve/s3/list.go
@@ -8,12 +8,13 @@ import (
 	"github.com/Mikubill/gofakes3"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/walk"
+	"github.com/rclone/rclone/vfs"
 )
 
-func (db *s3Backend) entryListR(bucket, fdPath, name string, acceptComPrefix bool, response *gofakes3.ObjectList) error {
+func (db *s3Backend) entryListR(vf *vfs.VFS, bucket, fdPath, name string, acceptComPrefix bool, response *gofakes3.ObjectList) error {
 	fp := path.Join(bucket, fdPath)
 
-	dirEntries, err := getDirEntries(fp, db.fs)
+	dirEntries, err := getDirEntries(fp, vf)
 	if err != nil {
 		return err
 	}
@@ -33,7 +34,7 @@ func (db *s3Backend) entryListR(bucket, fdPath, name string, acceptComPrefix boo
 				response.AddPrefix(gofakes3.URLEncode(objectPath))
 				continue
 			}
-			err := db.entryListR(bucket, path.Join(fdPath, object), "", false, response)
+			err := db.entryListR(vf, bucket, path.Join(fdPath, object), "", false, response)
 			if err != nil {
 				return err
 			}
@@ -52,10 +53,9 @@ func (db *s3Backend) entryListR(bucket, fdPath, name string, acceptComPrefix boo
 }
 
 // getObjectsList lists the objects in the given bucket.
-func (db *s3Backend) getObjectsListArbitrary(bucket string, prefix *gofakes3.Prefix, response *gofakes3.ObjectList) error {
-
+func (db *s3Backend) getObjectsListArbitrary(vf *vfs.VFS, bucket string, prefix *gofakes3.Prefix, response *gofakes3.ObjectList) error {
 	// ignore error - vfs may have uncommitted updates, such as new dir etc.
-	_ = walk.ListR(context.Background(), db.fs.Fs(), bucket, false, -1, walk.ListObjects, func(entries fs.DirEntries) error {
+	_ = walk.ListR(context.Background(), vf.Fs(), bucket, false, -1, walk.ListObjects, func(entries fs.DirEntries) error {
 		for _, entry := range entries {
 			entry := entry.(fs.Object)
 			objName := entry.Remote()

--- a/cmd/serve/s3/logger.go
+++ b/cmd/serve/s3/logger.go
@@ -3,7 +3,7 @@ package s3
 import (
 	"fmt"
 
-	"github.com/Mikubill/gofakes3"
+	"github.com/JankariTech/gofakes3"
 	"github.com/rclone/rclone/fs"
 )
 

--- a/cmd/serve/s3/pager.go
+++ b/cmd/serve/s3/pager.go
@@ -4,7 +4,7 @@ package s3
 import (
 	"sort"
 
-	"github.com/Mikubill/gofakes3"
+	"github.com/JankariTech/gofakes3"
 )
 
 // pager splits the object list into smulitply pages.

--- a/cmd/serve/s3/s3.go
+++ b/cmd/serve/s3/s3.go
@@ -44,18 +44,19 @@ var Command = &cobra.Command{
 	Long:  strings.ReplaceAll(longHelp, "|", "`") + httplib.Help(flagPrefix) + vfs.Help,
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(1, 1, command, args)
-		f := cmd.NewFsSrc(args)
+		// f := cmd.NewFsSrc(args)
 
-		if Opt.hashName == "auto" {
-			Opt.hashType = f.Hashes().GetOne()
-		} else if Opt.hashName != "" {
+		// if Opt.hashName == "auto" {
+		// 	Opt.hashType = f.Hashes().GetOne()
+		// } else
+		if Opt.hashName != "" {
 			err := Opt.hashType.Set(Opt.hashName)
 			if err != nil {
 				return err
 			}
 		}
 		cmd.Run(false, false, command, func() error {
-			s, err := newServer(context.Background(), f, &Opt)
+			s, err := newServer(context.Background(), args, &Opt)
 			if err != nil {
 				return err
 			}

--- a/cmd/serve/s3/s3.go
+++ b/cmd/serve/s3/s3.go
@@ -44,19 +44,18 @@ var Command = &cobra.Command{
 	Long:  strings.ReplaceAll(longHelp, "|", "`") + httplib.Help(flagPrefix) + vfs.Help,
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(1, 1, command, args)
-		// f := cmd.NewFsSrc(args)
+		f := cmd.NewFsSrc(args)
 
-		// if Opt.hashName == "auto" {
-		// 	Opt.hashType = f.Hashes().GetOne()
-		// } else
-		if Opt.hashName != "" {
+		if Opt.hashName == "auto" {
+			Opt.hashType = f.Hashes().GetOne()
+		} else if Opt.hashName != "" {
 			err := Opt.hashType.Set(Opt.hashName)
 			if err != nil {
 				return err
 			}
 		}
 		cmd.Run(false, false, command, func() error {
-			s, err := newServer(context.Background(), args, &Opt)
+			s, err := newServer(context.Background(), f, &Opt)
 			if err != nil {
 				return err
 			}

--- a/cmd/serve/s3/s3_test.go
+++ b/cmd/serve/s3/s3_test.go
@@ -8,8 +8,25 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/backend/webdav"
+	"github.com/rclone/rclone/cmd/serve/servetest"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config"
+	"github.com/rclone/rclone/fs/config/configfile"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/hash"
+	"github.com/rclone/rclone/fs/object"
+	"github.com/rclone/rclone/fstest"
+	httplib "github.com/rclone/rclone/lib/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"io"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
@@ -17,30 +34,105 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
-	"github.com/rclone/rclone/fs/object"
-
-	_ "github.com/rclone/rclone/backend/local"
-	"github.com/rclone/rclone/cmd/serve/servetest"
-	"github.com/rclone/rclone/fs"
-	"github.com/rclone/rclone/fs/config/configmap"
-	"github.com/rclone/rclone/fs/hash"
-	"github.com/rclone/rclone/fstest"
-	httplib "github.com/rclone/rclone/lib/http"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
-	endpoint = "localhost:0"
+	endpoint             = "localhost:0"
+	propfindResponseRoot = `
+<d:multistatus
+	xmlns:d="DAV:"
+	xmlns:s="http://sabredav.org/ns"
+	xmlns:oc="http://owncloud.org/ns"
+	xmlns:nc="http://nextcloud.org/ns">
+	<d:response>
+		<d:href>/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:displayname>admin</d:displayname>
+				<d:getlastmodified>Mon, 26 Jun 2023 04:17:38 GMT</d:getlastmodified>
+				<d:resourcetype>
+					<d:collection/>
+				</d:resourcetype>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength/>
+				<d:getcontenttype/>
+				<oc:checksums/>
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/bucket/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:displayname>bucket</d:displayname>
+				<d:getlastmodified>Fri, 16 Jun 2023 11:11:32 GMT</d:getlastmodified>
+				<d:resourcetype>
+					<d:collection/>
+				</d:resourcetype>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength/>
+				<d:getcontenttype/>
+				<oc:checksums/>
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/bucket2/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:displayname>bucket2</d:displayname>
+				<d:getlastmodified>Tue, 20 Jun 2023 04:00:56 GMT</d:getlastmodified>
+				<d:resourcetype>
+					<d:collection/>
+				</d:resourcetype>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength/>
+				<d:getcontenttype/>
+				<oc:checksums/>
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/newbucket/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:displayname>newbucket</d:displayname>
+				<d:getlastmodified>Mon, 19 Jun 2023 07:38:24 GMT</d:getlastmodified>
+				<d:resourcetype>
+					<d:collection/>
+				</d:resourcetype>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength/>
+				<d:getcontenttype/>
+				<oc:checksums/>
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>`
 )
 
 // Configure and serve the server
-func serveS3(f fs.Fs) (testURL string, keyid string, keysec string) {
-	keyid = RandString(16)
-	keysec = RandString(16)
+func serveS3(f fs.Fs, keyid string, keysec string) (testURL string) {
 	serveropt := &Options{
 		HTTP:           httplib.DefaultCfg(),
 		pathBucketMode: true,
@@ -52,7 +144,6 @@ func serveS3(f fs.Fs) (testURL string, keyid string, keysec string) {
 	serveropt.HTTP.ListenAddr = []string{endpoint}
 	w, _ := newServer(context.Background(), f, serveropt)
 	router := w.Router()
-
 	w.Bind(router)
 	w.Serve()
 	testURL = w.Server.URLs()[0]
@@ -75,7 +166,9 @@ func RandString(n int) string {
 // s3 remote against it.
 func TestS3(t *testing.T) {
 	start := func(f fs.Fs) (configmap.Simple, func()) {
-		testURL, keyid, keysec := serveS3(f)
+		keyid := RandString(16)
+		keysec := RandString(16)
+		testURL := serveS3(f, keyid, keysec)
 		// Config for the backend we'll use to connect to the server
 		config := configmap.Simple{
 			"type":              "s3",
@@ -147,6 +240,60 @@ func RunS3UnitTests(t *testing.T, name string, start servetest.StartFn) {
 	assert.NoError(t, err, "Running "+name+" integration tests")
 }
 
+func prepareWebDavServer(t *testing.T, keyid string) func() {
+	// test the headers are there send a dummy response to About
+	expectedAuthHeader := "Bearer " + keyid
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//what := fmt.Sprintf("%s %s: Header ", r.Method, r.URL.Path)
+		//assert.Equal(t, headers[1], r.Header.Get(headers[0]), what+headers[0])
+		assert.Equal(t, expectedAuthHeader, r.Header.Get("Authorization"))
+		fmt.Fprintf(w, propfindResponseRoot)
+	})
+
+	// Make the test server
+	ts := httptest.NewServer(handler)
+
+	_ = config.SetConfigPath("./testdata/webdav-tests.conf")
+
+	// Configure the remote
+	configfile.Install()
+	err := config.SetValueAndSave("webdavtest", "url", ts.URL)
+	assert.NoError(t, err)
+
+	// return a function to tidy up
+	return ts.Close
+}
+
+// prepare the test server and return a function to tidy it up afterwards
+func prepareWebDavFs(t *testing.T, keyid string) (fs.Fs, func()) {
+	tidy := prepareWebDavServer(t, keyid)
+
+	// Instantiate the WebDAV server
+	f, err := webdav.NewFs(context.Background(), "webdavtest", "", configmap.Simple{})
+	require.NoError(t, err)
+
+	return f, tidy
+}
+
+func TestForwardAccessKeyToWebDav(t *testing.T) {
+	keyid := RandString(16)
+	keysec := RandString(16)
+	f, clean := prepareWebDavFs(t, keyid)
+	defer clean()
+	endpoint := serveS3(f, keyid, keysec)
+	testURL, _ := url.Parse(endpoint)
+	minioClient, err := minio.New(testURL.Host, &minio.Options{
+		Creds:  credentials.NewStaticV4(keyid, keysec, ""),
+		Secure: false,
+	})
+	assert.NoError(t, err)
+	buckets, err := minioClient.ListBuckets(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, buckets[0].Name, "bucket")
+	assert.Equal(t, buckets[1].Name, "bucket2")
+
+}
+
 // tests using the minio client
 func TestEncodingWithMinioClient(t *testing.T) {
 	cases := []struct {
@@ -193,8 +340,9 @@ func TestEncodingWithMinioClient(t *testing.T) {
 			)
 			_, err = f.Put(context.Background(), in, obji)
 			assert.NoError(t, err)
-
-			endpoint, keyid, keysec := serveS3(f)
+			keyid := RandString(16)
+			keysec := RandString(16)
+			endpoint := serveS3(f, keyid, keysec)
 			testURL, _ := url.Parse(endpoint)
 			minioClient, err := minio.New(testURL.Host, &minio.Options{
 				Creds:  credentials.NewStaticV4(keyid, keysec, ""),

--- a/cmd/serve/s3/server.go
+++ b/cmd/serve/s3/server.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"net/http"
 
-	"github.com/Mikubill/gofakes3"
+	"github.com/JankariTech/gofakes3"
 	"github.com/go-chi/chi/v5"
 	"github.com/rclone/rclone/fs/hash"
 	httplib "github.com/rclone/rclone/lib/http"

--- a/cmd/serve/s3/server.go
+++ b/cmd/serve/s3/server.go
@@ -9,11 +9,8 @@ import (
 
 	"github.com/Mikubill/gofakes3"
 	"github.com/go-chi/chi/v5"
-	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/hash"
 	httplib "github.com/rclone/rclone/lib/http"
-	"github.com/rclone/rclone/vfs"
-	"github.com/rclone/rclone/vfs/vfsflags"
 )
 
 // Options contains options for the http Server
@@ -30,24 +27,22 @@ type Options struct {
 // Server is a s3.FileSystem interface
 type Server struct {
 	*httplib.Server
-	f       fs.Fs
-	vfs     *vfs.VFS
 	faker   *gofakes3.GoFakeS3
 	handler http.Handler
 	ctx     context.Context // for global config
+	args    []string
 }
 
 // Make a new S3 Server to serve the remote
-func newServer(ctx context.Context, f fs.Fs, opt *Options) (s *Server, err error) {
+func newServer(ctx context.Context, args []string, opt *Options) (s *Server, err error) {
 	w := &Server{
-		f:   f,
-		ctx: ctx,
-		vfs: vfs.New(f, &vfsflags.Opt),
+		ctx:  ctx,
+		args: args,
 	}
 
 	var newLogger logger
 	w.faker = gofakes3.New(
-		newBackend(w.vfs, opt),
+		newBackend(opt, w),
 		gofakes3.WithHostBucket(!opt.pathBucketMode),
 		gofakes3.WithLogger(newLogger),
 		gofakes3.WithRequestID(rand.Uint64()),

--- a/cmd/serve/s3/server.go
+++ b/cmd/serve/s3/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/JankariTech/gofakes3"
 	"github.com/go-chi/chi/v5"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/hash"
 	httplib "github.com/rclone/rclone/lib/http"
 )
@@ -27,17 +28,17 @@ type Options struct {
 // Server is a s3.FileSystem interface
 type Server struct {
 	*httplib.Server
+	f       fs.Fs
 	faker   *gofakes3.GoFakeS3
 	handler http.Handler
 	ctx     context.Context // for global config
-	args    []string
 }
 
 // Make a new S3 Server to serve the remote
-func newServer(ctx context.Context, args []string, opt *Options) (s *Server, err error) {
+func newServer(ctx context.Context, f fs.Fs, opt *Options) (s *Server, err error) {
 	w := &Server{
-		ctx:  ctx,
-		args: args,
+		f:   f,
+		ctx: ctx,
 	}
 
 	var newLogger logger

--- a/cmd/serve/s3/testdata/webdav-tests.conf
+++ b/cmd/serve/s3/testdata/webdav-tests.conf
@@ -1,0 +1,6 @@
+[webdavtest]
+type = webdav
+url = http://127.0.0.1:40777
+vendor = nextcloud
+nextcloud_chunk_size = 0
+

--- a/cmd/serve/s3/utils.go
+++ b/cmd/serve/s3/utils.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/Mikubill/gofakes3"
+	"github.com/JankariTech/gofakes3"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/vfs"
 )

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
+	github.com/JankariTech/gofakes3 v0.0.0-20230622065030-1b69ffde3106
 	github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd
-	github.com/Mikubill/gofakes3 v0.0.3-0.20230622102024-284c0f988700
 	github.com/Unknwon/goconfig v1.0.0
 	github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15
 	github.com/aalpar/deheap v0.0.0-20210914013432-0cc84d79dec3

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 h1:OBhqkivkhkM
 github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0/go.mod h1:kgDmCTgBzIEPFElEF+FK0SdjAor06dRq2Go927dnQ6o=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/JankariTech/gofakes3 v0.0.0-20230622065030-1b69ffde3106 h1:eUn1uYewfc26nWQP0b4BkqegoEtf4KJjt9O+nIs0Zyk=
+github.com/JankariTech/gofakes3 v0.0.0-20230622065030-1b69ffde3106/go.mod h1:TUu8ssPGUhHRypzW2cbsTJjVf84m0/WYPgK4ua1vBoo=
 github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd h1:nzE1YQBdx1bq9IlZinHa+HVffy+NmVRoKr+wHN8fpLE=
 github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd/go.mod h1:C8yoIfvESpM3GD07OCHU7fqI7lhwyZ2Td1rbNbTAhnc=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=


### PR DESCRIPTION
#### What is the purpose of this change?
When s3 is served with WebDAV backend (backend without auth), the authorization is done by parsing the bearer token set in the s3 requests as accessKey.
With this PR, the fs and vfs for remote (backend) are created per request and cached per access token. This gives us the ability to store and use the token for the same request it was parsed from thus eliminating the problem of handling multiple requests at once.

The changes are dependent on [1b69ff](https://github.com/JankariTech/gofakes3/commit/1b69ffde3106e8c37b4800c78dbed14a0af29b3d) version of gofakes3

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
